### PR TITLE
fix: Resolve Android build failure and update CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,5 +26,11 @@ jobs:
       with:
         gradle-version: '8.5'
 
-    - name: Build with Gradle
-      run: gradle build
+    - name: Build debug APK
+      run: gradle assembleDebug
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v3
+      with:
+        name: app-debug
+        path: app/build/outputs/apk/debug/app-debug.apk

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+# Indicates that the project uses AndroidX artifacts.
+android.useAndroidX=true
+# Automatically converts third-party libraries to use AndroidX.
+android.enableJetifier=true


### PR DESCRIPTION
This commit addresses a build failure in the GitHub Actions workflow and adds a step to upload the generated APK as a build artifact.

- Creates a `gradle.properties` file and sets `android.useAndroidX=true` and `android.enableJetifier=true` to resolve the dependency issue with AndroidX libraries.
- Modifies the `.github/workflows/android.yml` to use the `gradle assembleDebug` command to ensure the APK is built.
- Adds an `upload-artifact` step to the workflow to save the generated `app-debug.apk` for easy access.